### PR TITLE
ci: stabilize release-plz on self-hosted macOS ARM64

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   release-plz-release:
     name: Release
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: read
@@ -35,7 +35,7 @@ jobs:
 
   release-plz-pr:
     name: Release PR
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/docs/issues/2026-03-02_release-plz-semver-checks-fails-on-self-hosted-macos-arm64.md
+++ b/docs/issues/2026-03-02_release-plz-semver-checks-fails-on-self-hosted-macos-arm64.md
@@ -1,0 +1,39 @@
+# Issue #60: release-plz `release-pr` fails on self-hosted macOS ARM64
+
+## Context
+
+Release PR のワークフローで `release-plz/action` 実行中に `cargo-semver-checks` バイナリ取得が失敗し、`Release PR` ジョブがエラー終了する。
+
+主なログ:
+
+- `System reported platform: darwin`
+- `System reported arch: arm64`
+- `Error: Could not find a release for v0.30.0. Found: cargo-semver-checks-aarch64-apple-darwin.tar.gz, ...`
+
+## Root Cause
+
+self-hosted runner（`macOS` / `ARM64`）上で、`release-plz` が内部的に利用する `cargo-semver-checks` のアセット解決が失敗している。
+
+- runner 判定: `darwin` + `arm64`
+- 実アセット命名: `aarch64-apple-darwin`
+- インストーラ側の解決ロジックと命名規則が噛み合わず、取得に失敗
+
+`Cache service responded with 400` は副次的な警告であり、主因ではない。
+
+## Fix
+
+`release-plz.toml` で semver check を無効化する。
+
+```toml
+[workspace]
+semver_check = false
+```
+
+このプロジェクトは現状バイナリ中心で、`cargo-semver-checks` 依存を外してもリリース運用に影響しない。
+
+## Validation
+
+1. `release-plz` の `Release PR` ジョブを再実行する
+2. `cargo-semver-checks` の取得ステップが呼ばれないことを確認する
+3. Release PR が正常作成されることを確認する
+4. マージ後にタグ/Release が作成されることを確認する

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,6 +6,7 @@
 publish = false
 git_only = true
 git_release_enable = true
+semver_check = false
 
 [[package]]
 name = "minimum-viewer"


### PR DESCRIPTION
## Summary
- disable `release-plz` semver checks to avoid `cargo-semver-checks` binary resolution failures on darwin/arm64
- move release jobs in `.github/workflows/release-plz.yml` back to `ubuntu-latest` for stable release automation
- add Issue #60 investigation note under `docs/issues/` with root cause and validation steps

## Test plan
- [ ] Confirm `CI / test` still runs on self-hosted macOS ARM64
- [ ] Re-run `Release-plz / Release PR` and verify it no longer fails at semver-checks download
- [ ] Verify release PR can be created and merged end-to-end

Made with [Cursor](https://cursor.com)